### PR TITLE
Luxcium/patch 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "displayName": "Linux Desktop File support",
     "description": "Add support for .desktop files in linux",
     "icon": "assets/extension_icon.png",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "engines": {
         "vscode": "^1.52.0"
     },

--- a/syntaxes/desktop.tmLanguage.json
+++ b/syntaxes/desktop.tmLanguage.json
@@ -44,7 +44,7 @@
 			"patterns": [
 				{
 					"name": "keyword",
-					"match": "^Name|^Comment|^GenericName|^Exec|^Icon(?![A-z])|^Type|^StartupNotify|^StartupWMClass|^Categories|^MimeType|^Actions|^Keywords|^X-Desktop-File-Install-Version|^Terminal"
+					"match": "^Type|^Version|^Name|^GenericName|^NoDisplay|^Comment|^Icon|^Hidden|^OnlyShowIn|^NotShowIn|^DBusActivatable|^TryExec|^Exec|^Path|^Terminal|^Actions|^MimeType|^Categories|^Implements|^Keywords|^StartupNotify|^StartupWMClass|^URL|^PrefersNonDefaultGPU"
 				},
 				{
 					"name": "constant.language",


### PR DESCRIPTION
Some keys are missing in one of my configs therefore I added those missing keys following the documentation marked below


Update to: [Recognized desktop entry keys ― Table 2. Standard Keys](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)

![Screenshot_20210717_080352](https://user-images.githubusercontent.com/42672814/126036271-d6225488-2f04-431c-af00-cd9fddf643dc.png)
