### PR TITLE
Typo, X-Gnome-Metetheme -> Metatheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ For the full documentation of *.desktop* files, visit the freedesktop
 - *Theme: Monokai Dark*
 
 ## Theme Index Files
-Additionally, this extension highlights `[X-GNOME-Metetheme]` and it's keys.
 Additionally, this extension highlights `[X-GNOME-Metatheme]` and it's keys.
 
 <!-- <img width="625" height="303" src="assets/theme-screenshot.png"> -->

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For the full documentation of *.desktop* files, visit the freedesktop
 
 ## Theme Index Files
 Additionally, this extension highlights `[X-GNOME-Metetheme]` and it's keys.
+Additionally, this extension highlights `[X-GNOME-Metatheme]` and it's keys.
 
 <!-- <img width="625" height="303" src="assets/theme-screenshot.png"> -->
 <img width="625" height="303" src="https://raw.githubusercontent.com/nico-castell/desktop-file-support/main/assets/theme-screenshot.png">


### PR DESCRIPTION
Thanks for your extension!

Impossible to use because of a glaring typo. Typo is fixed. Can use now ;-)

\o/